### PR TITLE
Fix the calculation of numbers of samples to read.

### DIFF
--- a/src/MAX30100.cpp
+++ b/src/MAX30100.cpp
@@ -144,7 +144,11 @@ void MAX30100::readFifoData()
     uint8_t buffer[MAX30100_FIFO_DEPTH * 4];
     uint8_t toRead;
 
-    toRead = (readRegister(MAX30100_REG_FIFO_WRITE_POINTER) - readRegister(MAX30100_REG_FIFO_READ_POINTER)) & (MAX30100_FIFO_DEPTH - 1);
+    if(readRegister(MAX30100_REG_FIFO_OVERFLOW_COUNTER) == 0)
+        toRead = (readRegister(MAX30100_REG_FIFO_WRITE_POINTER) - readRegister(MAX30100_REG_FIFO_READ_POINTER)) & (MAX30100_FIFO_DEPTH-1);
+    else
+        toRead = 16;
+
 
     if (toRead)
     {


### PR DESCRIPTION
On branch master
Your branch is up to date with 'origin/master'.

Changes to be committed:
	modified:   src/MAX30100.cpp

The calculation of numbers of samples to read in MAX30100::readFifoData() doesn't consider the situation when the FIFO is full. I add the check for whether the FIFO overflow counter is not 0 to detect this. If the FIFO is full, set the number of samples to read to 16. This can prevent not reading any data because the FIFO write pointer pointed to the same position as FIFO read pointer does.